### PR TITLE
[WIP] feat: Support build / development environment via nix

### DIFF
--- a/python/camera/requirements.txt
+++ b/python/camera/requirements.txt
@@ -6,3 +6,4 @@ matplotlib
 numpy
 opencv-contrib-python~=4.4.0.46
 scipy
+pykalman

--- a/python/camera/requirements.txt
+++ b/python/camera/requirements.txt
@@ -6,4 +6,3 @@ matplotlib
 numpy
 opencv-contrib-python~=4.4.0.46
 scipy
-typing

--- a/python/shell.nix
+++ b/python/shell.nix
@@ -1,0 +1,35 @@
+let
+  mach-nix = import (builtins.fetchGit {
+    url = "https://github.com/DavHau/mach-nix/";
+    rev = "31b21203a1350bff7c541e9dfdd4e07f76d874be"; # master
+    #ref = "refs/tags/3.3.0";
+  }) {
+    python = "python39Full";
+  };
+
+  imutils = mach-nix.buildPythonPackage {
+    src = builtins.fetchGit{
+      url = "https://github.com/PyImageSearch/imutils";
+      ref = "master";
+      # rev = "put_commit_hash_here";
+    };
+    requirements = ''
+      setuptools
+    '';
+  };
+
+in
+mach-nix.buildPythonPackage {
+  src = ./.;
+  pname = "synch.live";
+  version = "0.0.1";
+
+  propagatedBuildInputs = [
+    imutils
+    mach-nix.nixpkgs.jdk8_headless
+  ];
+
+  # NOTE: use master / own version of imutils
+  requirements = builtins.replaceStrings [ "imutils" ] [ "" ] 
+    (builtins.readFile ./camera/requirements.txt);
+}

--- a/python/shell.nix
+++ b/python/shell.nix
@@ -1,8 +1,8 @@
 let
   mach-nix = import (builtins.fetchGit {
     url = "https://github.com/DavHau/mach-nix/";
-    rev = "31b21203a1350bff7c541e9dfdd4e07f76d874be"; # master
-    #ref = "refs/tags/3.3.0";
+    #rev = "31b21203a1350bff7c541e9dfdd4e07f76d874be"; # master
+    ref = "refs/tags/3.4.0";
   }) {
     python = "python39Full";
   };


### PR DESCRIPTION
# Motivation

Nix helps make development environments + package builds reproducible.

# Modifications

- add a `shell.nix` to `./python` sub-directory
- remove `typing` from `camera/requirements.txt`
  - `typing` is no longer required in python versions [above 3.5](https://docs.python.org/3/library/typing.html)
- [WIP] update documentation to show usage with `nix`
- [WIP] update documentation to link towards `nix` installation on Linux / MacOS

## Extra Notes

- Nix is not supported on Windows natively (only via WSL).
- Currently some extra packages are not included in the `shell.nix`, such as:
  - OpenCV with Wayland / QT support included
- Currently only the python `camera` package is supported via Nix, ansible + other scripts support will be added in the future.