### PR TITLE
feat(observer): support for any video device connected to observer

### DIFF
--- a/python/camera/README.md
+++ b/python/camera/README.md
@@ -144,10 +144,37 @@ or
 
 ### Running the Observer
 
+#### Raspberry Pi
+
 > **Note**: this can only be run on a RaspberryPi with a PiCamera attached.
 
     $ cd python
     $ python3 camera/server/server.py observer
 
+#### Generic Camera
 
+> **Note**: this has only been tested on Linux
 
+You can run the observer if you have a camera connected to your computer, this can be:
++ integrated laptop camera
++ external USB webcam
++ camera/stream connected via a Capture Card
+
+> Generic Camera's cannot be calibrated from the internal webpage, unlike the RaspberryPi Camera.
+
+##### Linux
+
+Your user must be a part of the `video` group, or you must have permission to access the video device in `/dev/videoN`
+
+check which camera device you may want to use `mpv`
+
+    $ mpv /dev/video0
+
+in this case my webcam is at index 0.
+
+If you do not see your video stream, then check the available video devices with `ls /dev | grep video` and try other indices.
+
+Using the index of your camera that you found earlir, run
+
+    $ cd python
+    $ CAMERA_NUMBER=0 python3 camera/server/server.py observer

--- a/python/camera/server/server.py
+++ b/python/camera/server/server.py
@@ -153,7 +153,7 @@ if __name__ == '__main__':
     camera_number = os.environ.get('CAMERA_NUMBER', default=None)
     camera_stream = None
     if camera_number != None:
-        camera_stream = VideoStream(int(camera_number))
+        camera_stream = VideoStream(int(camera_number), framerate = 12.0)
 
     create_app(server_type, camera_stream=camera_stream).run(host=host,
             port=port, debug=True, threaded=True, use_reloader=False)

--- a/python/camera/server/video.py
+++ b/python/camera/server/video.py
@@ -196,8 +196,11 @@ class VideoProcessor():
             a generator that produces a stream of bytes with the frame wrapped
             in a HTML response
         """
+        framerate = 12.0
+        frametime = 1.0/framerate
         while self.running:
             # wait until the lock is acquired
+            begin = time.time()
             with self.lock:
                 # check if the output frame is available, otherwise skip
                 # the iteration of the loop
@@ -211,6 +214,12 @@ class VideoProcessor():
             # yield the output frame in the byte format
             yield(b'--frame\r\n' b'Content-Type: image/jpeg\r\n\r\n' +
                 bytearray(encoded_frame) + b'\r\n')
+            end = time.time()
+            diff = end - begin
+            if diff > frametime:
+                continue
+            else:
+                time.sleep(frametime - diff) 
 
 
     def start(self) -> None:

--- a/python/camera/server/video.py
+++ b/python/camera/server/video.py
@@ -34,7 +34,8 @@ class VideoProcessor():
     """
     def __init__(self, use_picamera: bool, task: str = '',
             record: bool = True, annotate: bool = True,
-            video: str = '', record_path = 'media/video'):
+            video: str = '', record_path = 'media/video',
+            camera_stream = None):
         """
 		Params
 		------
@@ -57,6 +58,7 @@ class VideoProcessor():
         self.record         = record
         self.annotate       = annotate
         self.use_picamera   = use_picamera
+        self.camera_stream  = camera_stream
         self.record_path    = record_path
         self.video          = video
 
@@ -235,6 +237,9 @@ class VideoProcessor():
                 self.picamera.awb_mode = "sunlight"
 
                 time.sleep(2)
+            elif self.camera_stream:
+                self.video_stream = self.camera_stream
+                self.video_stream.start()
             else:
                 if not os.path.isfile(self.video):
                     raise ValueError(f'No such file: {self.video}')


### PR DESCRIPTION
## Motivation

Some parts of the code cannot be tested without a RaspberryPi with a PiCamera installed.
Additionally the observer is limited to only using pre-recorded videos or the PiCamera

## Modifications

- [x] support for using any video device available to observer
- [x] tested on integrated webcam (linux)
- [x] update documentation
- [x] test with external webcam
- [x] add guard check to calibration page (only compatible with PiCamera)
- [x] add frame-rate limiting to generic video stream

## Running Notes

- you (or the runner of `server.py`) must be part of the `video` unix group
- check your video devices (`ls /dev | grep video`)
- run with `CAMERA_NUMBER=0 python camera/server/server.py observer`, to select `/dev/video0`