### PR TITLE
feat(observer): support for any video device connected to observer

### DIFF
--- a/python/camera/README.md
+++ b/python/camera/README.md
@@ -161,10 +161,37 @@ or
 To run the server on the Observer of the Synch.Live system, the config file can
 be set in the same way using the env varibale `CONFIG_PATH`
 
+#### Raspberry Pi
+
 > **Note**: this can only be run on a RaspberryPi with a PiCamera attached.
 
     $ cd python
     $ python3 camera/server/server.py observer
 
+#### Generic Camera
 
+> **Note**: this has only been tested on Linux
 
+You can run the observer if you have a camera connected to your computer, this can be:
++ integrated laptop camera
++ external USB webcam
++ camera/stream connected via a Capture Card
+
+> Generic Camera's cannot be calibrated from the internal webpage, unlike the RaspberryPi Camera.
+
+##### Linux
+
+Your user must be a part of the `video` group, or you must have permission to access the video device in `/dev/videoN`
+
+check which camera device you may want to use `mpv`
+
+    $ mpv /dev/video0
+
+in this case my webcam is at index 0.
+
+If you do not see your video stream, then check the available video devices with `ls /dev | grep video` and try other indices.
+
+Using the index of your camera that you found earlir, run
+
+    $ cd python
+    $ CAMERA_NUMBER=0 python3 camera/server/server.py observer

--- a/python/camera/README.md
+++ b/python/camera/README.md
@@ -194,4 +194,4 @@ If you do not see your video stream, then check the available video devices with
 Using the index of your camera that you found earlir, run
 
     $ cd python
-    $ CAMERA_NUMBER=0 python3 camera/server/server.py observer
+    $ CONFIG_PATH=./camera/config/generic-camera.yml python3 camera/server/server.py observer

--- a/python/camera/config/generic-camera.yml
+++ b/python/camera/config/generic-camera.yml
@@ -1,0 +1,32 @@
+server:
+  RECORD: false
+  RECORD_PATH: ../media/video
+  IMG_PATH: ../media/img
+  HOST: 0.0.0.0
+  PORT: 8888
+  CAMERA: 0
+game:
+  task: "emergence"
+tracking:
+  max_players: 10
+  annotate: true
+detection:
+  min_contour: 100
+  max_contour: 500
+  min_colour:
+    hue: 50
+    saturation: 170
+    value: 100
+  max_colour:
+    hue: 85
+    saturation: 255
+    value: 255
+camera:
+  framerate: 12
+  resolution:
+    width: 640
+    height: 480
+  iso: 100
+  saturation: 100
+  shutter_speed: 31250
+  awb_mode: "sunlight"

--- a/python/camera/server/server.py
+++ b/python/camera/server/server.py
@@ -149,7 +149,7 @@ if __name__ == '__main__':
         #       so we create the camera stream here
         camera_number = config.server.CAMERA
         camera_stream = None
-        if camera_number != None:
+        if camera_number != None and type(camera_number) == int:
             logging.info(f"Opening Camera {camera_number}")
             camera_stream = VideoStream(int(camera_number), framerate = config.camera.framerate)
 

--- a/python/camera/server/server.py
+++ b/python/camera/server/server.py
@@ -151,7 +151,7 @@ if __name__ == '__main__':
         camera_stream = None
         if camera_number != None:
             logging.info(f"Opening Camera {camera_number}")
-            camera_stream = VideoStream(int(camera_number))
+            camera_stream = VideoStream(int(camera_number), framerate = config.camera.framerate)
 
         create_app(server_type, config, conf_path, camera_stream=camera_stream).run(
                 host = host, port = port, debug = True,

--- a/python/camera/server/video.py
+++ b/python/camera/server/video.py
@@ -375,8 +375,11 @@ class VideoProcessor():
             a generator that produces a stream of bytes with the frame wrapped
             in a HTML response
         """
+        framerate = 12.0
+        frametime = 1.0/framerate
         while self.running:
             # wait until the lock is acquired
+            begin = time.time()
             with self.lock:
                 # check if the output frame is available, otherwise skip
                 # the iteration of the loop
@@ -390,6 +393,12 @@ class VideoProcessor():
             # yield the output frame in the byte format
             yield(b'--frame\r\n' b'Content-Type: image/jpeg\r\n\r\n' +
                 bytearray(encoded_frame) + b'\r\n')
+            end = time.time()
+            diff = end - begin
+            if diff > frametime:
+                continue
+            else:
+                time.sleep(frametime - diff) 
 
 
     def start(self) -> None:


### PR DESCRIPTION
## Motivation

Some parts of the code cannot be tested without a RaspberryPi with a PiCamera installed.
Additionally the observer is limited to only using pre-recorded videos or the PiCamera

## Modifications

- [x] support for using any video device available to observer
- [x] tested on integrated webcam (linux)
- [x] update documentation
- [x] test with external webcam
- [x] add guard check to calibration page (only compatible with PiCamera)
- [x] add frame-rate limiting to generic video stream

## Running Notes

- you (or the runner of `server.py`) must be part of the `video` unix group
- check your video devices (`ls /dev | grep video`)
- run with `CAMERA_NUMBER=0 python camera/server/server.py observer`, to select `/dev/video0`